### PR TITLE
Deferred deletion check: support RHEL7.4+ kernels

### DIFF
--- a/deferred_deletion_check/standalone_deferred_deletion_check.sh
+++ b/deferred_deletion_check/standalone_deferred_deletion_check.sh
@@ -11,9 +11,37 @@ fi
 
 echo "Kernel version: $(uname -r)"
 
+# For RHEL/CentOS 7.4+, we need to enable this sysfs knob
+KEY=fs.may_detach_mounts
+M=$(sysctl -n "$KEY") \
+	&& [ "$M" -eq "0" ] \
+	&& {
+		sysctl -q "$KEY=1"
+		RESET_SYSCTL=true
+
+		cat << EOF
+
+WARNING: it seems you are using RHEL/CentOS 7.4+ kernel but the
+$KEY sysfs setting is disabled (set to 0).
+
+Setting $KEY = 1 for the duration of the test.
+
+To enable this permanently, run the following:
+
+	echo "$KEY=1" | sudo tee -a /etc/sysctl.d/90-docker.conf
+	sudo sysctl -f /etc/sysctl.d/90-docker.conf
+
+EOF
+}
+
 if platform_supports_deferred_deletion
 then
   echo "Deferred deletion is supported"
 else
   echo "Deferred deletion is not supported"
+fi
+
+if [ "$RESET_SYSCTL" = "true" ]
+then
+  sysctl -q "$KEY=0"
 fi


### PR DESCRIPTION
These kernels have the feature for deferred deletion built-in
but disabled by default. A sysctl knob is available to turn it on.

This patch checks if the knob is available but not enabled -- in
this case case it enables it for the duration of the test and gives
a user a recommendation on how to enable it permanently.

### BEFORE
```
[root@kir-ce73-gd docker-devicemapper-setup]#
./deferred_deletion_check/standalone_deferred_deletion_check.sh
Kernel version: 3.10.0-693.2.2.el7.x86_64
Deferred deletion is not supported
```
### AFTER
```
[root@kir-ce73-gd docker-devicemapper-setup]#
./deferred_deletion_check/standalone_deferred_deletion_check.sh
Kernel version: 3.10.0-693.2.2.el7.x86_64

WARNING: it seems you are using RHEL/CentOS 7.4+ kernel but the
fs.may_detach_mounts sysfs setting is disabled (set to 0).

Setting fs.may_detach_mounts = 1 for the duration of the test.

To enable this permanently, run the following:

	echo "fs.may_detach_mounts=1" | sudo tee -a
/etc/sysctl.d/90-docker.conf
	sudo sysctl -f /etc/sysctl.d/90-docker.conf

Deferred deletion is supported
```

[v2: drop use of trap as it's used elsewhere]

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>